### PR TITLE
Remove usage of flask_api HTTP constants and fix versions of requirements.

### DIFF
--- a/datapipeline/__init__.py
+++ b/datapipeline/__init__.py
@@ -12,7 +12,6 @@ import requests
 
 # Module imports
 from flask import Blueprint, current_app, jsonify, request, send_file
-from flask_api import status
 
 name = 'DataPipeline'
 prefix = 'datapipeline'
@@ -160,7 +159,7 @@ result_execution_folder_name = 'execution'
 
 @plugin.route('/')
 def index():
-    return f'This is the Radon CTT Agent Data Pipeline Plugin.', status.HTTP_200_OK
+    return f'This is the Radon CTT Agent Data Pipeline Plugin.', 200
 
 ############# Data Ppeline Testing Plugin #############
 
@@ -237,7 +236,7 @@ def configuration_create():
             res_zip.extractall(resources_extract_dir)
 
     else:
-        return 'No resources archive location provided.', status.HTTP_400_BAD_REQUEST
+        return 'No resources archive location provided.', 400
 
 
     persistence['configuration'][configuration_uuid] = config_instance
@@ -249,7 +248,7 @@ def configuration_create():
         }
     }
 
-    return jsonify(return_json), status.HTTP_201_CREATED
+    return jsonify(return_json), 201
 
 
 # Get/Delete Configuration
@@ -263,15 +262,15 @@ def configuration_get_delete(config_uuid):
                     'entry': persistence['configuration'][config_uuid]
                 }
             }
-            return jsonify(return_json), status.HTTP_200_OK
+            return jsonify(return_json), 200
 
         if request.method == 'DELETE':
             del persistence['configuration'][config_uuid]
             shutil.rmtree(os.path.join(storage_path, config_uuid))
-            return 'Successfully deleted ' + config_uuid + '.', status.HTTP_200_OK
+            return 'Successfully deleted ' + config_uuid + '.', 200
 
     else:
-        return "No configuration with that ID found", status.HTTP_404_NOT_FOUND
+        return "No configuration with that ID found", 404
 
 
 # Run load test (param: configuration uuid)
@@ -299,25 +298,25 @@ def execution():
             target_host = config_entry['host']
             current_app.logger.info(f'Setting host to {target_host}')
         else:
-            return "Configuration does not contain a host value.", status.HTTP_404_NOT_FOUND
+            return "Configuration does not contain a host value.", 404
 
         if 'test_duration_sec' in config_entry:
             test_duration_sec = config_entry['test_duration_sec']
             current_app.logger.info(f'Setting test_duration_sec to {test_duration_sec}')
         else:
-            return "Configuration does not contain a test_duration_sec value.", status.HTTP_404_NOT_FOUND
+            return "Configuration does not contain a test_duration_sec value.", 404
 
         if 'velocity_per_minute' in config_entry:
             velocity_per_minute = config_entry['velocity_per_minute']
             current_app.logger.info(f'Setting velocity_per_minute to {velocity_per_minute}')
         else:
-            return "Configuration does not contain a test_duration_sec value.", status.HTTP_404_NOT_FOUND
+            return "Configuration does not contain a test_duration_sec value.", 404
 
         if 'host' in config_entry:
             target_host = config_entry['host']
             current_app.logger.info(f'Setting host to {target_host}')
         else:
-            return "Configuration does not contain a host value.", status.HTTP_404_NOT_FOUND
+            return "Configuration does not contain a host value.", 404
 
 
         os.mkdir(execution_path)
@@ -380,10 +379,10 @@ def execution():
 
         persistence['execution'][execution_uuid] = execution_instance
 
-        return jsonify(execution_instance), status.HTTP_201_CREATED
+        return jsonify(execution_instance), 201
 
     else:
-        return "No configuration with that ID found.", jsonify(persistence), status.HTTP_404_NOT_FOUND
+        return "No configuration with that ID found.", jsonify(persistence), 404
 
 
 # Get load test results
@@ -392,11 +391,11 @@ def execution_results(exec_uuid):
     try:
         config_uuid = persistence.get('execution').get(exec_uuid).get('config').get('uuid')
     except AttributeError:
-        return "No execution found with that ID.", status.HTTP_404_NOT_FOUND
+        return "No execution found with that ID.", 404
 
     results_zip_path = os.path.join(storage_path, config_uuid, exec_uuid, result_zip_file_name)
     if os.path.isfile(results_zip_path):
         return send_file(results_zip_path)
     else:
-        return "No results available (yet).", status.HTTP_404_NOT_FOUND
+        return "No results available (yet).", 404
 

--- a/datapipeline/requirements.txt
+++ b/datapipeline/requirements.txt
@@ -1,3 +1,2 @@
-flask
-flask_api
-requests
+flask==2.0
+requests==2.25.1

--- a/http/__init__.py
+++ b/http/__init__.py
@@ -7,7 +7,6 @@ import tempfile
 import uuid
 
 from flask import Blueprint, current_app, jsonify, request, send_file
-from flask_api import status
 
 
 name = 'HTTP'
@@ -35,7 +34,7 @@ result_zip_file_name = 'results.zip'
 
 @plugin.route('/')
 def index():
-    return f'This is the Radon CTT Agent HTTP Plugin.', status.HTTP_200_OK
+    return f'This is the Radon CTT Agent HTTP Plugin.', 200
 
 
 @plugin.route('/configuration/', methods=['POST'])
@@ -91,11 +90,11 @@ def configuration_create():
 
         if is_required and param not in config_instance:
             current_app.logger.error(f"Required parameter {param} not provided.")
-            return f'Required parameter {param} not provided.', status.HTTP_400_BAD_REQUEST
+            return f'Required parameter {param} not provided.', 400
 
     persistence['configuration'][configuration_uuid] = config_instance
     current_app.logger.info(f"Config: {config_instance}")
-    return jsonify(config_instance), status.HTTP_201_CREATED
+    return jsonify(config_instance), 201
 
 
 @plugin.route('/execution/', methods=['POST'])
@@ -154,12 +153,12 @@ def execution():
                 shutil.copy2(tmp_zip_file, os.path.join(execution_results_dir, result_zip_file_name))
 
             # Test was executed with any possible outcome
-            return jsonify(execution_instance), status.HTTP_200_OK
+            return jsonify(execution_instance), 200
 
         else:
-            return "Required configuration parameters are missing.", jsonify(config_entry), status.HTTP_400_BAD_REQUEST
+            return "Required configuration parameters are missing.", jsonify(config_entry), 400
     else:
-        return "No configuration with that ID found.", jsonify(persistence), status.HTTP_404_NOT_FOUND
+        return "No configuration with that ID found.", jsonify(persistence), 404
 
 
 # Get execution results
@@ -168,10 +167,10 @@ def execution_results(exec_uuid):
     try:
         execution_uuid = persistence.get('execution').get(exec_uuid).get('uuid')
     except AttributeError:
-        return "No execution found with that ID.", status.HTTP_404_NOT_FOUND
+        return "No execution found with that ID.", 404
 
     results_zip_path = os.path.join(storage_path, execution_uuid, result_zip_file_name)
     if os.path.isfile(results_zip_path):
         return send_file(results_zip_path)
     else:
-        return "No results available (yet).", status.HTTP_404_NOT_FOUND
+        return "No results available (yet).", 404

--- a/http/requirements.txt
+++ b/http/requirements.txt
@@ -1,3 +1,2 @@
-flask
-flask_api
-requests
+flask==2.0
+requests==2.25.1

--- a/jmeter/__init__.py
+++ b/jmeter/__init__.py
@@ -9,7 +9,6 @@ import zipfile
 
 # Module imports
 from flask import Blueprint, current_app, jsonify, request, send_file
-from flask_api import status
 
 name = 'JMeter'
 prefix = 'jmeter'
@@ -23,7 +22,7 @@ def register(app, plugin_storage_path=None):
     app.register_blueprint(plugin, url_prefix=f'/{prefix}')
     app.logger.info(f'{name} plugin registered.')
     global storage_path
-    storage_path= plugin_storage_path
+    storage_path = plugin_storage_path
 
 
 persistence = {
@@ -51,7 +50,7 @@ result_execution_folder_name = 'execution'
 
 @plugin.route('/')
 def index():
-    return f'This is the Radon CTT Agent JMeter Plugin.', status.HTTP_200_OK
+    return f'This is the Radon CTT Agent JMeter Plugin.', 200
 
 
 ############# JMETER #############
@@ -119,7 +118,7 @@ def configuration_create():
         elif 'jmx_file_name' not in request.form:
             error_str = f'\'jmx_file_name\' could not be found in \'request.form\''
         else:
-            error_str = f'No test resources and/or JMX file name provided.', status.HTTP_400_BAD_REQUEST
+            error_str = f'No test resources and/or JMX file name provided.', 400
 
         current_app.logger.error(error_str)
         raise FileNotFoundError(error_str)
@@ -141,7 +140,7 @@ def configuration_create():
         }
     }
 
-    return jsonify(return_json), status.HTTP_201_CREATED
+    return jsonify(return_json), 201
 
 
 # Get/Delete Configuration
@@ -155,15 +154,15 @@ def configuration_get_delete(config_uuid):
                     'entry': persistence['configuration'][config_uuid]
                 }
             }
-            return jsonify(return_json), status.HTTP_200_OK
+            return jsonify(return_json), 200
 
         if request.method == 'DELETE':
             del persistence['configuration'][config_uuid]
             shutil.rmtree(os.path.join(storage_path, config_uuid))
-            return 'Successfully deleted ' + config_uuid + '.', status.HTTP_200_OK
+            return 'Successfully deleted ' + config_uuid + '.', 200
 
     else:
-        return "No configuration with that ID found", status.HTTP_404_NOT_FOUND
+        return "No configuration with that ID found", 404
 
 
 # Run load test (param: configuration uuid)
@@ -218,7 +217,7 @@ def execution():
                 jmeter_cli_call.append('-p ' + os.path.join(config_entry['properties_path']))
 
         else:
-            return "Configuration does not contain a test plan.", status.HTTP_404_NOT_FOUND
+            return "Configuration does not contain a test plan.", 404
 
         execution_instance['cli_call'] = jmeter_cli_call
 
@@ -237,10 +236,10 @@ def execution():
 
         persistence['execution'][execution_uuid] = execution_instance
 
-        return jsonify(execution_instance), status.HTTP_201_CREATED
+        return jsonify(execution_instance), 201
 
     else:
-        return "No configuration with that ID found.", jsonify(persistence), status.HTTP_404_NOT_FOUND
+        return "No configuration with that ID found.", jsonify(persistence), 404
 
 
 # Get load test results
@@ -249,10 +248,10 @@ def execution_results(exec_uuid):
     try:
         config_uuid = persistence.get('execution').get(exec_uuid).get('config').get('uuid')
     except AttributeError:
-        return "No execution found with that ID.", status.HTTP_404_NOT_FOUND
+        return "No execution found with that ID.", 404
 
     results_zip_path = os.path.join(storage_path, config_uuid, exec_uuid, result_zip_file_name)
     if os.path.isfile(results_zip_path):
         return send_file(results_zip_path)
     else:
-        return "No results available (yet).", status.HTTP_404_NOT_FOUND
+        return "No results available (yet).", 404

--- a/jmeter/requirements.txt
+++ b/jmeter/requirements.txt
@@ -1,2 +1,1 @@
-flask
-flask_api
+flask==2.0


### PR DESCRIPTION
Resolves radon-h2020/radon-ctt#99 for `radon-ctt-agent-plugins`

@pjakovits In order to resolve the issue mentioned above, I had to remove the usage of the `flask_api` status constants also in the datapipeline plugin. Apart from just replacing the constants with the actual integer status codes I did not alter your code.